### PR TITLE
WIP: fixes #6 - allow usage of Swift ID that differs from filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ before_install:
 
 rvm:
     - 2.3.3
+    - 2.4
+    - 2.5

--- a/lib/swift_ingest/ingestor.rb
+++ b/lib/swift_ingest/ingestor.rb
@@ -24,7 +24,7 @@ class SwiftIngest::Ingestor
              end
   end
 
-  # ToDo: refactor
+  # TODO: refactor
   # (a) to avoid reopening the container each time
   # (b) if not extension on the filename then potentially fails if base name contains a '.'
   def get_file_from_swit(file_name, swift_container)
@@ -72,7 +72,7 @@ class SwiftIngest::Ingestor
     else
       # for creating new: construct hash with symbols as keys, add metadata as a hash within the header hash
       headers = { etag: checksum,
-                  content_type:  'application/x-tar',
+                  content_type: 'application/x-tar',
                   metadata: metadata }
       deposited_file = container.create_object(id, headers, File.open(file_name))
     end

--- a/lib/swift_ingest/ingestor.rb
+++ b/lib/swift_ingest/ingestor.rb
@@ -41,7 +41,7 @@ class SwiftIngest::Ingestor
   end
 
   def deposit_file(file_name, swift_container, custom_metadata = {})
-    deposit_file(File.basename(file_name, '.*'), file_name, swift_container, custom_metadata)
+    deposit(File.basename(file_name, '.*'), file_name, swift_container, custom_metadata)
   end
 
   def deposit(id, file_name, swift_container, custom_metadata = {})

--- a/lib/swift_ingest/ingestor.rb
+++ b/lib/swift_ingest/ingestor.rb
@@ -24,6 +24,9 @@ class SwiftIngest::Ingestor
              end
   end
 
+  # ToDo: refactor
+  # (a) to avoid reopening the container each time
+  # (b) if not extension on the filename then potentially fails if base name contains a '.'
   def get_file_from_swit(file_name, swift_container)
     deposited_file = nil
     file_base_name = File.basename(file_name, '.*')
@@ -32,11 +35,16 @@ class SwiftIngest::Ingestor
     deposited_file
   end
 
-  def deposit_file(file_name, swift_container, custom_metadata = {})
-    deposit_file(File.basename(file_name, '.*'), file_name, swift_container, custom_metadata = {})
+  def lookup(id, swift_container)
+    container = swift_connection.container(swift_container)
+    container.object(id) if container.object_exists?(id)
   end
 
-  def deposit_file(id, file_name, swift_container, custom_metadata = {})
+  def deposit_file(file_name, swift_container, custom_metadata = {})
+    deposit_file(File.basename(file_name, '.*'), file_name, swift_container, custom_metadata)
+  end
+
+  def deposit(id, file_name, swift_container, custom_metadata = {})
     checksum = Digest::MD5.file(file_name).hexdigest
     container = swift_connection.container(swift_container)
 

--- a/swift_ingest.gemspec
+++ b/swift_ingest.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mysql2', '~> 0.4.6'
   s.add_runtime_dependency 'openstack', '~> 3.3', '>= 3.3.10'
 
-  s.add_development_dependency 'bundler', '~> 1.14'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'pry', '~> 0.10', '>= 0.10.4'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/swift_ingest.gemspec
+++ b/swift_ingest.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'swift_ingest/version'
 


### PR DESCRIPTION
fixes #6 

Add ability to specify an ID when calling the deposit method thus extending the functionality to allow specifying an ID that may not align with the filename.

E.g. cwrc_root.zip (filename) versus cwrc:root (PID) - in this case `_` used in the filename as `:` is not a supported filename on all operating systems.

The refactor aims to maintain backwards compatibility.